### PR TITLE
feat: change library type from dynamic to static

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,10 @@ let package = Package(
     .iOS(.v18), .macOS(.v15)
   ],
   products: [
+    // Static library - allows consuming apps to avoid use_frameworks! :linkage => :dynamic
     .library(
       name: "MisakiSwift",
-      type: .dynamic,
+      type: .static,
       targets: ["MisakiSwift"]
     ),
   ],


### PR DESCRIPTION
This allows consuming apps (especially React Native apps with CocoaPods) to avoid requiring use_frameworks! :linkage => :dynamic in their Podfile.

When built as a static library, all MLX dependencies are linked directly into the consuming binary rather than requiring separate dynamic frameworks.