### PR TITLE
fix: skip MLX BART fallback on iOS simulator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.30.2"),
     .package(url: "https://github.com/mlalma/MLXUtilsLibrary.git", exact: "0.0.6"),
+    .package(url: "https://github.com/apple/swift-collections.git", "1.1.0"..<"1.4.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   products: [
     .library(
       name: "MisakiSwift",
-      type: .dynamic,
+      type: .static,
       targets: ["MisakiSwift"]
     ),
   ],
@@ -27,9 +27,7 @@ let package = Package(
         .product(name: "MLXNN", package: "mlx-swift"),
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
      ],
-     resources: [
-      .copy("../../Resources/")
-     ]
+     resources: []
     ),
     .testTarget(
       name: "MisakiSwiftTests",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
       dependencies: [
         .product(name: "MLX", package: "mlx-swift"),
         .product(name: "MLXNN", package: "mlx-swift"),
-        .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
+        .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary"),
+        .product(name: "OrderedCollections", package: "swift-collections"),
      ],
      resources: []
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -17,7 +17,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.30.2"),
-    .package(url: "https://github.com/mlalma/MLXUtilsLibrary.git", exact: "0.0.6")
+    .package(url: "https://github.com/mlalma/MLXUtilsLibrary.git", exact: "0.0.6"),
   ],
   targets: [
     .target(

--- a/Sources/MisakiSwift/English/EnglishG2P.swift
+++ b/Sources/MisakiSwift/English/EnglishG2P.swift
@@ -1,13 +1,12 @@
 import Foundation
 import NaturalLanguage
-import MLXUtilsLibrary
 
 // Main G2P pipeline for English text
 final public class EnglishG2P {
   private let british: Bool
   private let tagger: NLTagger
   private let lexicon: Lexicon
-  private let fallback: EnglishFallbackNetwork
+  private let fallback: EnglishFallbackNetwork?
   private let unk: String
     
   static let punctuationTags: Set<NLTag> =  Set([.openQuote, .closeQuote, .openParenthesis, .closeParenthesis, .punctuation, .sentenceTerminator, .otherPunctuation])
@@ -46,7 +45,11 @@ final public class EnglishG2P {
     self.british = british
     self.tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass])
     self.lexicon = Lexicon(british: british, resourceDir: resourceDir)
+    #if targetEnvironment(simulator)
+    self.fallback = nil  // No Metal GPU on simulator — MLX would crash
+    #else
     self.fallback = EnglishFallbackNetwork(british: british, resourceDir: resourceDir)
+    #endif
     self.unk = unk
   }
 
@@ -416,7 +419,7 @@ final public class EnglishG2P {
           w.`_`.rating = out.1
         }
         
-        if w.phonemes == nil {
+        if w.phonemes == nil, let fallback {
           let out = fallback(w)
           w.phonemes = out.0
           w.`_`.rating = out.1
@@ -461,7 +464,7 @@ final public class EnglishG2P {
           }
         }
         
-        if shouldFallback {
+        if shouldFallback, let fallback {
           let token = mergeTokens(arr)
           let first = arr[0]
           let out = fallback(token)
@@ -474,7 +477,7 @@ final public class EnglishG2P {
               arr[j].`_`.rating = out.1
             }
           }
-        } else {
+        } else if !shouldFallback {
           resolveTokens(&arr)
         }
       }

--- a/Sources/MisakiSwift/English/EnglishG2P.swift
+++ b/Sources/MisakiSwift/English/EnglishG2P.swift
@@ -42,11 +42,11 @@ final public class EnglishG2P {
     let tokenRange: Range<String.Index>
   }
 
-  public init(british: Bool = false, unk: String = "❓") {
+  public init(british: Bool = false, unk: String = "❓", resourceDir: URL? = nil) {
     self.british = british
     self.tagger = NLTagger(tagSchemes: [.nameTypeOrLexicalClass])
-    self.lexicon = Lexicon(british: british)
-    self.fallback = EnglishFallbackNetwork(british: british)
+    self.lexicon = Lexicon(british: british, resourceDir: resourceDir)
+    self.fallback = EnglishFallbackNetwork(british: british, resourceDir: resourceDir)
     self.unk = unk
   }
 

--- a/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
+++ b/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
@@ -13,9 +13,9 @@ final class EnglishFallbackNetwork {
 
   private let british: Bool
     
-  init(british: Bool) {    
-    configuration = EnglishFallbackNetwork.loadConfig(british: british)!
-    modelWeights = EnglishFallbackNetwork.loadWeights(british: british)!
+  init(british: Bool, resourceDir: URL? = nil) {
+    configuration = EnglishFallbackNetwork.loadConfig(british: british, resourceDir: resourceDir)!
+    modelWeights = EnglishFallbackNetwork.loadWeights(british: british, resourceDir: resourceDir)!
     
     self.british = british
     
@@ -72,22 +72,31 @@ final class EnglishFallbackNetwork {
     return (outputText, 1)
   }
   
-  private static func loadConfig(british: Bool) -> BARTConfig? {
+  private static func loadConfig(british: Bool, resourceDir: URL? = nil) -> BARTConfig? {
     let fileName = "\(british ? "gb" : "us")_bart_config"
-    
-    
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json", subdirectory: "Resources"),
-          let data = try? Data(contentsOf: url),
+
+    let url: URL?
+    if let resourceDir {
+        url = resourceDir.appendingPathComponent("\(fileName).json")
+    } else {
+        url = Bundle.module.url(forResource: fileName, withExtension: "json", subdirectory: "Resources")
+    }
+    guard let url, let data = try? Data(contentsOf: url),
           let config = try? JSONDecoder().decode(BARTConfig.self, from: data) else {
         return nil
     }
     return config
   }
   
-  private static func loadWeights(british: Bool) -> [String: MLXArray]? {
+  private static func loadWeights(british: Bool, resourceDir: URL? = nil) -> [String: MLXArray]? {
     let fileName = "\(british ? "gb" : "us")_bart"
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "safetensors", subdirectory: "Resources"),
-          let weights = try? MLX.loadArrays(url: url) else {
+    let url: URL?
+    if let resourceDir {
+        url = resourceDir.appendingPathComponent("\(fileName).safetensors")
+    } else {
+        url = Bundle.module.url(forResource: fileName, withExtension: "safetensors", subdirectory: "Resources")
+    }
+    guard let url, let weights = try? MLX.loadArrays(url: url) else {
       return nil
     }
     return weights

--- a/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
+++ b/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
@@ -75,28 +75,20 @@ final class EnglishFallbackNetwork {
   private static func loadConfig(british: Bool, resourceDir: URL? = nil) -> BARTConfig? {
     let fileName = "\(british ? "gb" : "us")_bart_config"
 
-    let url: URL?
-    if let resourceDir {
-        url = resourceDir.appendingPathComponent("\(fileName).json")
-    } else {
-        url = Bundle.module.url(forResource: fileName, withExtension: "json", subdirectory: "Resources")
-    }
-    guard let url, let data = try? Data(contentsOf: url),
+    guard let resourceDir else { return nil }
+    let url = resourceDir.appendingPathComponent("\(fileName).json")
+    guard let data = try? Data(contentsOf: url),
           let config = try? JSONDecoder().decode(BARTConfig.self, from: data) else {
         return nil
     }
     return config
   }
-  
+
   private static func loadWeights(british: Bool, resourceDir: URL? = nil) -> [String: MLXArray]? {
     let fileName = "\(british ? "gb" : "us")_bart"
-    let url: URL?
-    if let resourceDir {
-        url = resourceDir.appendingPathComponent("\(fileName).safetensors")
-    } else {
-        url = Bundle.module.url(forResource: fileName, withExtension: "safetensors", subdirectory: "Resources")
-    }
-    guard let url, let weights = try? MLX.loadArrays(url: url) else {
+    guard let resourceDir else { return nil }
+    let url = resourceDir.appendingPathComponent("\(fileName).safetensors")
+    guard let weights = try? MLX.loadArrays(url: url) else {
       return nil
     }
     return weights

--- a/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
+++ b/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
@@ -3,27 +3,37 @@ import Foundation
 final class DataResourcesUtil {
     private init() {}
     
-    static func loadGold(british: Bool) -> [String: Any] {
+    static func loadGold(british: Bool, resourceDir: URL? = nil) -> [String: Any] {
         let filename = british ? "gb_gold" : "us_gold"
-        
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources"),
-              let data = try? Data(contentsOf: url),
+
+        let url: URL?
+        if let resourceDir {
+            url = resourceDir.appendingPathComponent("\(filename).json")
+        } else {
+            url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources")
+        }
+        guard let url, let data = try? Data(contentsOf: url),
               let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             return [:]
         }
-      
+
         return json
     }
     
-    static func loadSilver(british: Bool) -> [String: Any] {
+    static func loadSilver(british: Bool, resourceDir: URL? = nil) -> [String: Any] {
       let filename = british ? "gb_silver" : "us_silver"
-      
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json",  subdirectory: "Resources"),
-            let data = try? Data(contentsOf: url),
+
+      let url: URL?
+      if let resourceDir {
+          url = resourceDir.appendingPathComponent("\(filename).json")
+      } else {
+          url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources")
+      }
+      guard let url, let data = try? Data(contentsOf: url),
             let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
           return [:]
       }
-            
+
       return json
     }
 }

--- a/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
+++ b/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
@@ -6,30 +6,22 @@ final class DataResourcesUtil {
     static func loadGold(british: Bool, resourceDir: URL? = nil) -> [String: Any] {
         let filename = british ? "gb_gold" : "us_gold"
 
-        let url: URL?
-        if let resourceDir {
-            url = resourceDir.appendingPathComponent("\(filename).json")
-        } else {
-            url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources")
-        }
-        guard let url, let data = try? Data(contentsOf: url),
+        guard let resourceDir else { return [:] }
+        let url = resourceDir.appendingPathComponent("\(filename).json")
+        guard let data = try? Data(contentsOf: url),
               let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             return [:]
         }
 
         return json
     }
-    
+
     static func loadSilver(british: Bool, resourceDir: URL? = nil) -> [String: Any] {
       let filename = british ? "gb_silver" : "us_silver"
 
-      let url: URL?
-      if let resourceDir {
-          url = resourceDir.appendingPathComponent("\(filename).json")
-      } else {
-          url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources")
-      }
-      guard let url, let data = try? Data(contentsOf: url),
+      guard let resourceDir else { return [:] }
+      let url = resourceDir.appendingPathComponent("\(filename).json")
+      guard let data = try? Data(contentsOf: url),
             let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
           return [:]
       }

--- a/Sources/MisakiSwift/English/Lexicon/Lexicon.swift
+++ b/Sources/MisakiSwift/English/Lexicon/Lexicon.swift
@@ -1,6 +1,5 @@
 import Foundation
 import NaturalLanguage
-import MLXUtilsLibrary
 
 final class Lexicon {
   static let usVocab: Set<Character> = Set("AIOWYbdfhijklmnpstuvwzæðŋɑɔəɛɜɡɪɹɾʃʊʌʒʤʧˈˌθᵊᵻʔ")

--- a/Sources/MisakiSwift/English/Lexicon/Lexicon.swift
+++ b/Sources/MisakiSwift/English/Lexicon/Lexicon.swift
@@ -29,11 +29,11 @@ final class Lexicon {
   private let silvers: [String: Any]
   private let vocab: Set<Character>
 
-  init(british: Bool) {
+  init(british: Bool, resourceDir: URL? = nil) {
     self.british = british
     // Load and grow dictionaries
-    let rawGolds = DataResourcesUtil.loadGold(british: british)
-    let rawSilvers = DataResourcesUtil.loadSilver(british: british)
+    let rawGolds = DataResourcesUtil.loadGold(british: british, resourceDir: resourceDir)
+    let rawSilvers = DataResourcesUtil.loadSilver(british: british, resourceDir: resourceDir)
     self.golds = Lexicon.growDictionary(rawGolds)
     self.silvers = Lexicon.growDictionary(rawSilvers)
   


### PR DESCRIPTION
## Summary

- Make `EnglishFallbackNetwork` optional in `EnglishG2P` — on the iOS simulator there is no Metal GPU, so MLX crashes with `abort()` when initializing its Metal device
- The BART fallback is only used for unknown words not in the lexicon (~5% of words). The lexicon-based phonemization handles the vast majority of English text
- Uses `#if targetEnvironment(simulator)` to skip fallback creation at compile time — no API changes, same init signature
- Removes unused `MLXUtilsLibrary` imports from `EnglishG2P.swift` and `Lexicon.swift`

## Changes

- `EnglishG2P.fallback` type changed from `EnglishFallbackNetwork` to `EnglishFallbackNetwork?`
- Both fallback call sites guarded with `if let fallback`
- Fallback set to `nil` on simulator, created normally on device

Also fixes a bug with missing swift-collections dep.