### PR TITLE
feat: add dictionaryOnly mode for background-safe G2P

### DIFF
--- a/Sources/MisakiSwift/English/EnglishG2P.swift
+++ b/Sources/MisakiSwift/English/EnglishG2P.swift
@@ -9,6 +9,11 @@ final public class EnglishG2P {
   private let lexicon: Lexicon
   private let fallback: EnglishFallbackNetwork
   private let unk: String
+
+  /// When `true`, skips MLX BART fallback for OOV words. Pure Swift dictionary
+  /// lookups (179K entries) still run. Use in iOS background mode where Metal
+  /// GPU is unavailable. OOV words will have nil phonemes.
+  public var dictionaryOnly: Bool = false
     
   static let punctuationTags: Set<NLTag> =  Set([.openQuote, .closeQuote, .openParenthesis, .closeParenthesis, .punctuation, .sentenceTerminator, .otherPunctuation])
   static let punctuactions: Set<Character> = Set(";:,.!?—…\"“”")
@@ -416,7 +421,7 @@ final public class EnglishG2P {
           w.`_`.rating = out.1
         }
         
-        if w.phonemes == nil {
+        if w.phonemes == nil && !dictionaryOnly {
           let out = fallback(w)
           w.phonemes = out.0
           w.`_`.rating = out.1
@@ -461,7 +466,7 @@ final public class EnglishG2P {
           }
         }
         
-        if shouldFallback {
+        if shouldFallback && !dictionaryOnly {
           let token = mergeTokens(arr)
           let first = arr[0]
           let out = fallback(token)


### PR DESCRIPTION
## Summary

Adds a `dictionaryOnly` property to `EnglishG2P` that skips the MLX BART OOV fallback while keeping pure-Swift dictionary lookups (179K entries) active.

## Use case

iOS apps using MisakiSwift with Kokoro TTS crash with `SIGABRT` when the MLX BART fallback runs in background mode — Metal GPU work is prohibited by iOS in background processes. Setting `g2p.dictionaryOnly = true` prevents this while maintaining near-full pronunciation quality (only rare OOV words miss, which callers can handle with a fallback G2P).

## Changes

- Added `public var dictionaryOnly: Bool = false` on `EnglishG2P`
- Guarded the two BART fallback call sites (`fallback(w)` for single words and `fallback(token)` for compound words) with `!dictionaryOnly`
- Dictionary lookups (`lexicon.transcribe`) always run regardless of the flag
- Zero behavior change when `dictionaryOnly = false` (default)

## Testing

Tested in Voxnotes iOS app: foreground renders use full G2P, background renders use dictionary-only mode. Audio plays continuously through lock screen with consistent quality.