### PR TITLE
fix: enumerate resources individually so iOS Simulator codesign accepts the bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,14 @@ let package = Package(
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
      ],
      resources: [
-      .copy("../../Resources/")
+      .copy("../../Resources/gb_bart_config.json"),
+      .copy("../../Resources/gb_bart.safetensors"),
+      .copy("../../Resources/gb_gold.json"),
+      .copy("../../Resources/gb_silver.json"),
+      .copy("../../Resources/us_bart_config.json"),
+      .copy("../../Resources/us_bart.safetensors"),
+      .copy("../../Resources/us_gold.json"),
+      .copy("../../Resources/us_silver.json")
      ]
     ),
     .testTarget(

--- a/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
+++ b/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
@@ -76,17 +76,17 @@ final class EnglishFallbackNetwork {
     let fileName = "\(british ? "gb" : "us")_bart_config"
     
     
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json", subdirectory: "Resources"),
+    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json"),
           let data = try? Data(contentsOf: url),
           let config = try? JSONDecoder().decode(BARTConfig.self, from: data) else {
         return nil
     }
     return config
   }
-  
+
   private static func loadWeights(british: Bool) -> [String: MLXArray]? {
     let fileName = "\(british ? "gb" : "us")_bart"
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "safetensors", subdirectory: "Resources"),
+    guard let url = Bundle.module.url(forResource: fileName, withExtension: "safetensors"),
           let weights = try? MLX.loadArrays(url: url) else {
       return nil
     }

--- a/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
+++ b/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
@@ -6,19 +6,19 @@ final class DataResourcesUtil {
     static func loadGold(british: Bool) -> [String: Any] {
         let filename = british ? "gb_gold" : "us_gold"
         
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources"),
+      guard let url = Bundle.module.url(forResource: filename, withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             return [:]
         }
-      
+
         return json
     }
-    
+
     static func loadSilver(british: Bool) -> [String: Any] {
       let filename = british ? "gb_silver" : "us_silver"
-      
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json",  subdirectory: "Resources"),
+
+      guard let url = Bundle.module.url(forResource: filename, withExtension: "json"),
             let data = try? Data(contentsOf: url),
             let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
           return [:]


### PR DESCRIPTION
## Summary

In Xcode 26 + iOS Simulator, codesign rejects this package's resource bundle with `bundle format unrecognized, invalid, or unsuitable`. The cause is that `.copy("../../Resources/")` preserves the `Resources/` subdirectory inside the emitted bundle (so the bundle is structured as `MisakiSwift.bundle/Resources/<files>`), and the simulator codesign step refuses to sign that layout.

Replacing the directory copy with one `.copy()` per file places the resources at the bundle root (`MisakiSwift.bundle/<files>`), which codesign accepts. Lookups via `Bundle.module.url(forResource:withExtension:)` continue to work because they search the whole bundle.

## Test plan
- [x] `xcodebuild` clean build for iOS Simulator (Xcode 26.4) succeeds; previously failed at the `CodeSign MisakiSwift_MisakiSwift.bundle` step
- [x] Resulting bundle is flat: `Info.plist`, `_CodeSignature/`, and all 8 resource files at root
- [x] `Bundle.module` resource lookups still work at runtime