### PR TITLE
Add missing pronunciation of "twenty"

### DIFF
--- a/Sources/MisakiSwift/English/Num2Word/EnglishNum2Word.swift
+++ b/Sources/MisakiSwift/English/Num2Word/EnglishNum2Word.swift
@@ -17,7 +17,7 @@ struct EnglishNum2Word {
     (1000, "thousand"), (100, "hundred"),
     (90, "ninety"), (80, "eighty"), (70, "seventy"),
     (60, "sixty"), (50, "fifty"), (40, "forty"),
-    (30, "thirty")
+    (30, "thirty"), (20, "twenty")
   ]
   
   private let lowNumWords = [

--- a/Tests/MisakiSwiftTests/EnglishNum2WordTests.swift
+++ b/Tests/MisakiSwiftTests/EnglishNum2WordTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import MisakiSwift
+
+@Test func cardinalNumbersInTheTwentiesIncludeTheTensWord() {
+  let numberConverter = EnglishNum2Word()
+
+  #expect(numberConverter.convert(Decimal(22)) == "twenty-two")
+  #expect(numberConverter.convert(Decimal(26)) == "twenty-six")
+}
+
+@Test func fourDigitYearIncludesBothTwoDigitGroups() {
+  let numberConverter = EnglishNum2Word()
+
+  #expect(numberConverter.convert(Decimal(2026), to: .year) == "twenty twenty-six")
+}
+
+@Test func threeDigitNumberKeepsCardinalHundredsPronunciation() {
+  let numberConverter = EnglishNum2Word()
+
+  #expect(numberConverter.convert(Decimal(376)) == "three hundred and seventy-six")
+}
+
+@Test func decimalPointSeparatesTheFractionalDigits() {
+  let numberConverter = EnglishNum2Word()
+
+  #expect(numberConverter.convert(Decimal(string: "20.26") ?? 0) == "twenty point two six")
+}


### PR DESCRIPTION
"twenty" is missing from the numbers pronunciation table, causing numbers like "2026" to get pronounced as "twenty-six".