### PR TITLE
fix: remove .dynamic type and use .process for Resources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
   products: [
     .library(
       name: "MisakiSwift",
-      type: .dynamic,
       targets: ["MisakiSwift"]
     ),
   ],
@@ -28,7 +27,7 @@ let package = Package(
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
      ],
      resources: [
-      .copy("Resources")
+      .process("Resources")
      ]
     ),
     .testTarget(


### PR DESCRIPTION
- Removed 'type: .dynamic' from library product (fixes build conflicts with other MLX deps, related to upstream issue #26)
- Changed .copy('Resources') to .process('Resources') (fixes 'bundle format unrecognized' codesign error on iOS archive/Xcode Cloud builds)