### PR TITLE
Fix resource bundle layout so the package can be code-signed for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
      ],
      resources: [
-      .copy("Resources")
+      .process("Resources")
      ]
     ),
     .testTarget(

--- a/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
+++ b/Sources/MisakiSwift/English/FallbackNetwork/EnglishFallbackNetwork.swift
@@ -76,7 +76,7 @@ final class EnglishFallbackNetwork {
     let fileName = "\(british ? "gb" : "us")_bart_config"
     
     
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json", subdirectory: "Resources"),
+    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json"),
           let data = try? Data(contentsOf: url),
           let config = try? JSONDecoder().decode(BARTConfig.self, from: data) else {
         return nil
@@ -86,7 +86,7 @@ final class EnglishFallbackNetwork {
   
   private static func loadWeights(british: Bool) -> [String: MLXArray]? {
     let fileName = "\(british ? "gb" : "us")_bart"
-    guard let url = Bundle.module.url(forResource: fileName, withExtension: "safetensors", subdirectory: "Resources"),
+    guard let url = Bundle.module.url(forResource: fileName, withExtension: "safetensors"),
           let weights = try? MLX.loadArrays(url: url) else {
       return nil
     }

--- a/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
+++ b/Sources/MisakiSwift/English/Lexicon/DataResourcesUtil.swift
@@ -6,7 +6,7 @@ final class DataResourcesUtil {
     static func loadGold(british: Bool) -> [String: Any] {
         let filename = british ? "gb_gold" : "us_gold"
         
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json", subdirectory: "Resources"),
+      guard let url = Bundle.module.url(forResource: filename, withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             return [:]
@@ -18,7 +18,7 @@ final class DataResourcesUtil {
     static func loadSilver(british: Bool) -> [String: Any] {
       let filename = british ? "gb_silver" : "us_silver"
       
-      guard let url = Bundle.module.url(forResource: filename, withExtension: "json",  subdirectory: "Resources"),
+      guard let url = Bundle.module.url(forResource: filename, withExtension: "json"),
             let data = try? Data(contentsOf: url),
             let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
           return [:]

--- a/Tests/MisakiSwiftTests/ResourceBundleTests.swift
+++ b/Tests/MisakiSwiftTests/ResourceBundleTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import MisakiSwift
+
+/// Regression guard that the library can still find its data after the resource layout changed.
+///
+/// **What this does NOT prove.** It does not verify the iOS fix. `.copy` keeps the files in a
+/// `Resources/` subdirectory and `.process` flattens them to the bundle root, but on macOS a bundle's
+/// `resourcePath` IS its `Resources/` directory — so `Bundle.url(forResource:)` resolves under both
+/// layouts and this suite passes either way. Measured, after it was written expecting the opposite.
+///
+/// The layout difference only exists on iOS, where bundles are flat, and it only manifests at
+/// `codesign`, which rejects the `.copy` shape as "bundle format unrecognized, invalid, or
+/// unsuitable". **That gate is an iOS build, not a test.**
+///
+/// What this suite is still worth: `.process` paired with lookups that pass
+/// `subdirectory: "Resources"` would return nil for everything, and this catches that — the failure
+/// would otherwise be silent, surfacing as bad pronunciation rather than an error.
+@Suite("Resource bundle layout")
+struct ResourceBundleTests {
+
+    @Test("every lexicon and model resolves from the bundle root")
+    func resourcesResolve() {
+        var missing: [String] = []
+        for name in ["us_gold", "us_silver", "us_bart_config", "gb_gold", "gb_silver", "gb_bart_config"] {
+            if Bundle.module.url(forResource: name, withExtension: "json") == nil { missing.append(name) }
+        }
+        for name in ["us_bart", "gb_bart"] {
+            if Bundle.module.url(forResource: name, withExtension: "safetensors") == nil { missing.append(name) }
+        }
+        #expect(missing.isEmpty, "unresolved: \(missing.joined(separator: ", "))")
+    }
+
+    /// The lookup the library actually performs, not just the file's presence.
+    @Test("the American lexicon loads and has entries")
+    func lexiconLoads() throws {
+        let url = try #require(Bundle.module.url(forResource: "us_gold", withExtension: "json"))
+        let data = try Data(contentsOf: url)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect((json?.count ?? 0) > 1000, "us_gold decoded but looks empty")
+    }
+}


### PR DESCRIPTION
## Problem

MisakiSwift cannot be linked into an iOS app. Any iOS target that depends on it fails to build:

```
MisakiSwift_MisakiSwift.bundle: bundle format unrecognized, invalid, or unsuitable
Command CodeSign failed with a nonzero exit code
```

The cause is `resources: [.copy("Resources")]`. `.copy` preserves the directory, so the built bundle
has `Info.plist` at its root and the data files under `Resources/` — a shape that matches neither the
flat iOS bundle layout nor the macOS `Contents/` layout. macOS tolerates it; iOS `codesign` rejects it.

It reproduces without any build system:

```
$ codesign --force --sign - .../MisakiSwift_MisakiSwift.bundle
...bundle format unrecognized, invalid, or unsuitable
```

This is independent of #6, which moved the resources under `Sources/MisakiSwift/` and fixed SPM path
resolution but kept `.copy`.

## Change

- `Package.swift`: `.copy("Resources")` → `.process("Resources")`, which flattens the files to the
  bundle root — the layout iOS accepts.
- `DataResourcesUtil.swift`, `EnglishFallbackNetwork.swift`: drop `subdirectory: "Resources"` from the
  four `Bundle.module.url(forResource:...)` calls.

**Both halves are required.** `.process` alone leaves the lookups pointing at a directory that no
longer exists, so every one returns `nil` and the lexicons fail to load — a silent failure that
surfaces as bad phonemization rather than an error.

## macOS impact: none

A macOS bundle's `resourcePath` *is* its `Resources/` directory, so `Bundle.url(forResource:)` resolves
under both layouts.

This is also why the added `ResourceBundleTests` **passes before and after this change** — its comment
says so explicitly rather than implying it guards the iOS fix. It is a regression guard against the
`.process`-with-stale-`subdirectory:` combination described above, which would otherwise fail silently.
The genuine verification for the iOS side is an iOS build.

## Verification

- iOS device build of an app linking MisakiSwift: succeeds (fails on `main`).
- macOS: package builds; a downstream macOS app suite of 1292 tests passes with no change in behaviour.
- Note unrelated to this PR: MLX does not link for the iOS **Simulator** (it references Metal symbols
  the simulator SDK does not export), so consumers of the fallback network are device-only on iOS.
